### PR TITLE
Fix mod not loading

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -31,8 +31,10 @@
 		"randomize-jumpscare-chance": {
 			"name": "Jumpscare Chance",
 			"description": "Change jumpscare chance.",
-			"type": "double",
-			"default": 1
+			"type": "float",
+			"default": 1,
+			"min": 0,
+			"max": 100
 		}
 	}
 }


### PR DESCRIPTION
`double` is not a valid type in Geode's config schema. The correct type is `float`.

https://docs.geode-sdk.org/mods/settings#supported-setting-types

I also chose to add a `min` and `max` to avoid negative percentages.

Fixes #8 